### PR TITLE
Fix ai-service entrypoint and clean task-service networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,6 @@ services:
     entrypoint: ../wait-for-it.sh config-server:8888 --timeout=20 -- java -jar task-service-1.0.jar
     networks:
       - project-management-system-network
-      -
   ai-service:
     image: ai-service-1.0
     deploy:
@@ -130,7 +129,7 @@ services:
     depends_on:
       - service-discovery
       - config-server
-    entrypoint: ../wait-for-it.sh config-server:8888 --timeout=20 -- java -jar task-service-1.0.jar
+    entrypoint: ../wait-for-it.sh config-server:8888 --timeout=20 -- java -jar ai-service-1.0.jar
     networks:
       - project-management-system-network
 


### PR DESCRIPTION
## Summary
- fix ai-service entrypoint
- remove stray dash under task-service networks

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441b5e0e28832181f12b0f3b7c2924