### PR TITLE
Fix duplicate user message

### DIFF
--- a/auth-service/src/main/java/local/pms/authservice/controller/AuthRestController.java
+++ b/auth-service/src/main/java/local/pms/authservice/controller/AuthRestController.java
@@ -63,7 +63,7 @@ public class AuthRestController {
         Optional<AuthUserDto> authUser = authService.findByUsername(signUpDto.username());
         if (authUser.isPresent() && authUser.get().username().equalsIgnoreCase(signUpDto.username())) {
             log.info("User '{}' with this username already exists in database", authUser.get().username());
-            return ResponseEntity.badRequest().body(authUser.get().username() + " is exists in databases");
+            return ResponseEntity.badRequest().body(authUser.get().username() + " already exists in the database");
         } else {
             authService.signUp(signUpDto);
             log.info("User '{}' successfully registered", signUpDto.username());


### PR DESCRIPTION
## Summary
- update `AuthRestController` sign-up duplicate message to read "already exists in the database"

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441c5c25c88321b1440b776f31273f